### PR TITLE
docs: fix remaining documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Join the discussion at [Blender Artists](https://blenderartists.org/t/simple-ren
 You can thank me by leaving a rating at [Gumroad](https://gumroad.com/l/simple_renaming "Gumroad") or sponsor a
 coffee.
 
-Documentation: https://weisl.github.io/renaming_overview/
+Documentation: https://weisl.github.io/simple_renaming/renaming_overview/
 
 


### PR DESCRIPTION
## Summary

- update the remaining README documentation link to include the project path
- keep both README references consistent with the manifest and in-app help link

Closes #241

## Validation

- confirmed the updated URL returns HTTP 200
- confirmed the obsolete URL returns HTTP 404 and no longer appears in tracked files
- `git diff --check`
